### PR TITLE
Fix #1: DTLoupe renderInContext: crash

### DIFF
--- a/Core/Source/DTLoupeView.m
+++ b/Core/Source/DTLoupeView.m
@@ -546,7 +546,7 @@ CGAffineTransform CGAffineTransformAndScaleMake(CGFloat sx, CGFloat sy, CGFloat 
     [self hideInvalidLayersInView:_targetRootView];
     
     // the loupe is not part of the rendered tree, so we don't need to hide it
-    [_targetRootView drawViewHierarchyInRect:_targetRootView.bounds afterScreenUpdates:YES];
+    [_targetRootView.layer renderInContext:ctx];
 	
 	UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 	_loupeContentsLayer.contents = (__bridge id)(image.CGImage);

--- a/Core/Source/DTLoupeView.m
+++ b/Core/Source/DTLoupeView.m
@@ -542,7 +542,7 @@ CGAffineTransform CGAffineTransformAndScaleMake(CGFloat sx, CGFloat sy, CGFloat 
     CGContextTranslateCTM(ctx,-convertedLocation.x, -convertedLocation.y);
     
     // the loupe is not part of the rendered tree, so we don't need to hide it
-    [_targetRootView.layer renderInContext:ctx];
+    [_targetRootView drawViewHierarchyInRect:_targetRootView.bounds afterScreenUpdates:YES];
 	
 	UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 	_loupeContentsLayer.contents = (__bridge id)(image.CGImage);

--- a/Core/Source/DTLoupeView.m
+++ b/Core/Source/DTLoupeView.m
@@ -541,6 +541,10 @@ CGAffineTransform CGAffineTransformAndScaleMake(CGFloat sx, CGFloat sy, CGFloat 
     
     CGContextTranslateCTM(ctx,-convertedLocation.x, -convertedLocation.y);
     
+    // On iOS 8, layers with invalid (x/y) or a frame equal to CGRectZero cause renderInContext: to fail.
+    // Hide those layers here to prevent that.
+    [self hideInvalidLayersInView:_targetRootView];
+    
     // the loupe is not part of the rendered tree, so we don't need to hide it
     [_targetRootView drawViewHierarchyInRect:_targetRootView.bounds afterScreenUpdates:YES];
 	
@@ -548,6 +552,37 @@ CGAffineTransform CGAffineTransformAndScaleMake(CGFloat sx, CGFloat sy, CGFloat 
 	_loupeContentsLayer.contents = (__bridge id)(image.CGImage);
 	
 	UIGraphicsEndImageContext();
+}
+
+- (void)hideInvalidLayersInView:(UIView *)rootView
+{
+    if ([self layerHasInvalidFrame:rootView.layer])
+    {
+        rootView.layer.hidden = YES;
+    }
+    
+    for (UIView *view in rootView.subviews)
+    {
+        if ([self layerHasInvalidFrame:view.layer])
+        {
+            view.layer.hidden = YES;
+        }
+        
+        for (CALayer *layer in view.layer.sublayers)
+        {
+            if ([self layerHasInvalidFrame:layer])
+            {
+                layer.hidden = YES;
+            }
+        }
+
+        [self hideInvalidLayersInView:view];
+    }
+}
+
+- (BOOL)layerHasInvalidFrame:(CALayer *)layer
+{
+    return CGRectIsEmpty(layer.bounds) || isnan((CGRectGetMinX(layer.frame))) || isnan((CGRectGetMinY(layer.frame)));
 }
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer

--- a/DTLoupe.xcodeproj/project.pbxproj
+++ b/DTLoupe.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -523,7 +523,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 			};
@@ -539,7 +539,6 @@
 				GCC_PREFIX_HEADER = "Demo/Demo-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "Demo/Demo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -554,7 +553,6 @@
 				GCC_PREFIX_HEADER = "Demo/Demo-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "Demo/Demo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALIDATE_PRODUCT = YES;
 				WRAPPER_EXTENSION = app;
@@ -581,7 +579,6 @@
 				);
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = DTLoupe;
@@ -604,7 +601,6 @@
 				GCC_PREFIX_HEADER = "Core/DTLoupe-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = DTLoupe;


### PR DESCRIPTION
I was able to repro consistently in the simulator. I can no longer reproduce after moving to the iOS 7 API. Can you try it in your sample and confirm that it's fixed with this change?

No need for the bounty. This didn't take long and I took a look during while waiting on something to compile.

Fix #1 
