### PR TITLE
Fixed a loupe orientation issue in iOS 9.

### DIFF
--- a/Core/Source/DTLoupeView.m
+++ b/Core/Source/DTLoupeView.m
@@ -299,12 +299,14 @@ CGAffineTransform CGAffineTransformAndScaleMake(CGFloat sx, CGFloat sy, CGFloat 
 
 - (CGAffineTransform)_loupeWindowTransform
 {
-	// beginning with iOS 8 we need to determine the rotation ourselves
-	if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1)
+	// Only on iOS 8, we need to determine the rotation ourselves
+    NSString* systemVersion = [[UIDevice currentDevice] systemVersion];
+	if ([systemVersion length] > 0 &&
+        ![[systemVersion substringToIndex:1] isEqualToString:@"8"])
 	{
 		return _targetRootView.transform;
 	}
-	
+    
 	UIInterfaceOrientation orientation = [self _inferredInterfaceOrientation];
 	
 	// the CGAffineTransformMakeRotation would return weird values from rotating, so we return exact values


### PR DESCRIPTION
Loupe orientation is wrong in iOS 9, as discussed [here](https://github.com/Cocoanetics/DTRichTextEditor/issues/10). 

It appears that the transform adjustment in `_loupeWindowTransform` is _only_ required on iOS 8, which is what I've done. Tested on iOS 8 and 9 iPads.
